### PR TITLE
Fixed issue where breaks Umbraco webservices 

### DIFF
--- a/src/BouncerModule.cs
+++ b/src/BouncerModule.cs
@@ -42,7 +42,7 @@ namespace Bouncer
             var application = (HttpApplication)sender;
             var context = application.Context;
             var path = context.Request.Url.AbsolutePath;
-            var extension = (path.Contains('.')) ? Path.GetExtension(path).Substring(1) : Path.GetExtension(path);
+            var extension = (path.Contains('.') && !string.IsNullOrWhiteSpace(Path.GetExtension(path)) ? Path.GetExtension(path).Substring(1) : Path.GetExtension(path);
 
             /*
              * Checking for excluded file extensions b/c it appears something is interfering with the mime/types


### PR DESCRIPTION
Fixes issue when the path contains a . stop in the middle of the relative path and not at the end

e.g /umbraco/webservice/blah.amsx/js

System.ArgumentOutOfRangeException: startIndex cannot be larger than length of string.
Parameter name: startIndex
at System.String.Substring(Int32 startIndex, Int32 length)
at Bouncer.BouncerModule.Start(Object sender, EventArgs e)
at System.Web.HttpApplication.SyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()
at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously)
